### PR TITLE
Composer 1_17 support

### DIFF
--- a/dags/bitcoinetl/build_load_dag.py
+++ b/dags/bitcoinetl/build_load_dag.py
@@ -157,7 +157,7 @@ def build_load_dag(
 
             sql_path = os.path.join(dags_folder, 'resources/stages/enrich/sqls/{task}.sql'.format(task=task))
             sql_template = read_file(sql_path)
-            sql = kwargs['task'].render_template('', sql_template, template_context)
+            sql = kwargs['task'].render_template(sql_template, template_context)
             print('Enrichment sql:')
             print(sql)
 
@@ -186,7 +186,7 @@ def build_load_dag(
                 merge_sql_path = os.path.join(dags_folder, 'resources/stages/enrich/sqls/merge_{task}.sql'.format(task=task))
                 merge_sql_template = read_file(merge_sql_path)
                 template_context['params']['source_table'] = temp_table_name
-                merge_sql = kwargs['task'].render_template('', merge_sql_template, template_context)
+                merge_sql = kwargs['task'].render_template(merge_sql_template, template_context)
                 print('Merge sql:')
                 print(merge_sql)
                 merge_job = client.query(merge_sql, location='US', job_config=merge_job_config)
@@ -224,7 +224,7 @@ def build_load_dag(
 
             sql_path = os.path.join(dags_folder, 'resources/stages/enrich/sqls/{task}.sql'.format(task=task))
             sql_template = read_file(sql_path)
-            sql = kwargs['task'].render_template('', sql_template, template_context)
+            sql = kwargs['task'].render_template(sql_template, template_context)
             table.view_query = sql
 
             description_path = os.path.join(


### PR DESCRIPTION
- Based on this [issue](https://github.com/blockchain-etl/bitcoin-etl-airflow/issues/7), this PR adds some changes from this [PR](https://github.com/blockchain-etl/ethereum-etl-airflow/pull/272/files) which is was opened in the [ethereum-etl-airflow](https://github.com/blockchain-etl/ethereum-etl-airflow) repo to support a more up to date composer version. The changes were tested using these versions

      composer=1.17.6
      airflow=1.10.15

- Based on this [comment](https://github.com/blockchain-etl/bitcoin-etl-airflow/blob/3414b7d481e2bb0342618fa64f384be08b71cb22/dags/bitcoinetl/build_export_dag.py#L43), I removed the usage of minconda to get python3 in favor of using python3 which is installed in the composer environment as it is now supported.

Closes #7 